### PR TITLE
Fix go build failed

### DIFF
--- a/cn.go
+++ b/cn.go
@@ -1,6 +1,6 @@
 package cryptonight
 
-// #cgo CFLAGS: -maes
+// #cgo CFLAGS: -march=native
 // #include "cn.h"
 import "C"
 import "unsafe"


### PR DESCRIPTION
-maes option is not in cgo option white list, use -march=native instead
native auto enables -maes when cpu arch is newer than sandy_bridge.